### PR TITLE
Feat/leaderboard 5

### DIFF
--- a/app/(frontend)/leaderboard/page.tsx
+++ b/app/(frontend)/leaderboard/page.tsx
@@ -1,6 +1,7 @@
 import { getPayload } from 'payload'
 import config from '@payload-config'
 import PlayerRowDisplay from './playerRowDisplay' 
+import Link from 'next/link'
 
 export default async function LeaderboardPage() { //api part
   const payload = await getPayload({ config })
@@ -13,7 +14,7 @@ export default async function LeaderboardPage() { //api part
   return ( //no styles.css file, can delete and change this whenever, just a placeholder
     <div className="p-8 font-sans flex flex-col items-center">
       <h1 className="text-3xl font-bold mb-6">Top 10 Leaderboard</h1>
-      <a href="/" className="mb-4 text-blue-500 hover:underline">Go back to Dashboard</a>
+      <Link href="/" className="mb-4 text-blue-500 hover:underline">Go back to Dashboard</Link>
 
       <div className="flex flex-col w-full items-center">
         {topPlayers.docs.map((player, index) => (

--- a/app/(frontend)/leaderboard/page.tsx
+++ b/app/(frontend)/leaderboard/page.tsx
@@ -2,7 +2,7 @@ import { getPayload } from 'payload'
 import config from '@payload-config'
 import PlayerRowDisplay from './playerRowDisplay' 
 
-export default async function LeaderboardPage() {
+export default async function LeaderboardPage() { //api part
   const payload = await getPayload({ config })
   const topPlayers = await payload.find({
     collection: 'Players', 
@@ -10,13 +10,14 @@ export default async function LeaderboardPage() {
     limit: 10,             
   })
 
-  return (
+  return ( //no styles.css file, can delete and change this whenever, just a placeholder
     <div className="p-8 font-sans flex flex-col items-center">
       <h1 className="text-3xl font-bold mb-6">Top 10 Leaderboard</h1>
-      
+      <a href="/" className="mb-4 text-blue-500 hover:underline">Go back to Dashboard</a>
+
       <div className="flex flex-col w-full items-center">
         {topPlayers.docs.map((player, index) => (
-          <PlayerRowDisplay 
+          <PlayerRowDisplay //separate element used for ui design
             key={player.id} 
             player={player} 
             rank={index + 1} 

--- a/app/(frontend)/leaderboard/page.tsx
+++ b/app/(frontend)/leaderboard/page.tsx
@@ -2,6 +2,7 @@ import { getPayload } from 'payload'
 import config from '@payload-config'
 import PlayerRowDisplay from './playerRowDisplay' 
 import Link from 'next/link'
+export const dynamic = 'force-dynamic';
 
 export default async function LeaderboardPage() { //api part
   const payload = await getPayload({ config })

--- a/app/(frontend)/leaderboard/page.tsx
+++ b/app/(frontend)/leaderboard/page.tsx
@@ -1,0 +1,28 @@
+import { getPayload } from 'payload'
+import config from '@payload-config'
+import PlayerRowDisplay from './playerRowDisplay' 
+
+export default async function LeaderboardPage() {
+  const payload = await getPayload({ config })
+  const topPlayers = await payload.find({
+    collection: 'Players', 
+    sort: '-score',        
+    limit: 10,             
+  })
+
+  return (
+    <div className="p-8 font-sans flex flex-col items-center">
+      <h1 className="text-3xl font-bold mb-6">Top 10 Leaderboard</h1>
+      
+      <div className="flex flex-col w-full items-center">
+        {topPlayers.docs.map((player, index) => (
+          <PlayerRowDisplay 
+            key={player.id} 
+            player={player} 
+            rank={index + 1} 
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/(frontend)/leaderboard/playerRowDisplay.tsx
+++ b/app/(frontend)/leaderboard/playerRowDisplay.tsx
@@ -1,0 +1,19 @@
+import { Player } from "@/payload-types";
+
+export default function playerRowDisplay({
+  player,
+  rank,
+}: {
+  player: Player;
+  rank: number;
+}) {
+  return (
+    <div className="flex flex-row gap-5 bg-black text-white rounded-lg text-xl p-3 mb-2 justify-between items-center w-full max-w-md">
+      <div className="flex gap-4">
+        <span className="text-slate-400 font-bold">#{rank}</span>
+        <h1>{player.userId || "Unknown Player"}</h1>
+      </div>
+      <h2 className="text-emerald-400 font-bold">{player.score}</h2>
+    </div>
+  );
+}

--- a/app/(frontend)/page.tsx
+++ b/app/(frontend)/page.tsx
@@ -51,6 +51,12 @@ export default async function HomePage() {
           >
             Example Collection
           </Link>
+          <Link
+            className="bg-black transition duration-200 hover:bg-sky-700 rounded-lg p-3"
+            href="/leaderboard"
+          >
+            Leaderboard
+          </Link>
         </div>
       </div>
 

--- a/collections/players.ts
+++ b/collections/players.ts
@@ -1,0 +1,16 @@
+import type { CollectionConfig } from "payload";
+
+export const Players: CollectionConfig = {
+  slug: "Players",
+  // What is stored in this collection
+  fields: [
+    {
+      name: "userId", //decided to go with userId instead of email to avoid signing in, can be changed if needed
+      type: "text",
+    },
+    {
+      name: "score",
+      type: "number",
+    },
+  ],
+};

--- a/collections/players.ts
+++ b/collections/players.ts
@@ -5,8 +5,8 @@ export const Players: CollectionConfig = {
   // What is stored in this collection
   fields: [
     {
-      name: "userId", //decided to go with userId instead of email to avoid signing in, can be changed if needed
-      type: "text",
+      name: "userId", //decided to go with userId instead of email to avoid signing in,
+      type: "text",   //can be changed if needed
     },
     {
       name: "score",

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -69,6 +69,7 @@ export interface Config {
   collections: {
     users: User;
     example: Example;
+    Players: Player;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -78,6 +79,7 @@ export interface Config {
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
     example: ExampleSelect<false> | ExampleSelect<true>;
+    Players: PlayersSelect<false> | PlayersSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -156,6 +158,17 @@ export interface Example {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "Players".
+ */
+export interface Player {
+  id: string;
+  userId?: string | null;
+  score?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -185,6 +198,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'example';
         value: string | Example;
+      } | null)
+    | ({
+        relationTo: 'Players';
+        value: string | Player;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -258,6 +275,16 @@ export interface UsersSelect<T extends boolean = true> {
 export interface ExampleSelect<T extends boolean = true> {
   title?: T;
   subTitle?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "Players_select".
+ */
+export interface PlayersSelect<T extends boolean = true> {
+  userId?: T;
+  score?: T;
   updatedAt?: T;
   createdAt?: T;
 }

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -166,6 +166,11 @@ export interface Player {
   id: string;
   userId?: string | null;
   score?: number | null;
+  updatedAt: string;
+  createdAt: string;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "Cart".
  */
 export interface Cart {
@@ -217,6 +222,8 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'Players';
         value: string | Player;
+      } | null)
+    | ({
         relationTo: 'Cart';
         value: string | Cart;
       } | null);
@@ -302,6 +309,11 @@ export interface ExampleSelect<T extends boolean = true> {
 export interface PlayersSelect<T extends boolean = true> {
   userId?: T;
   score?: T;
+  updatedAt?: T;
+  createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "Cart_select".
  */
 export interface CartSelect<T extends boolean = true> {

--- a/payload.config.ts
+++ b/payload.config.ts
@@ -4,12 +4,13 @@ import { mongooseAdapter } from "@payloadcms/db-mongodb";
 import { buildConfig } from "payload";
 import { ExampleCollection } from "./collections/exampleCollection.ts";
 import { Users } from "./collections/users.ts";
+import { Players } from "./collections/players.ts";
 
 export default buildConfig({
   editor: lexicalEditor(),
 
   // Ensure created collections are added here
-  collections: [Users, ExampleCollection],
+  collections: [Users, ExampleCollection, Players],
 
   secret: process.env.PAYLOAD_SECRET || "",
   db: mongooseAdapter({


### PR DESCRIPTION
<!-- Please provide a general summary of your changes in the Title above -->

## Issues

<!-- Close the issue this pr is linked to by typing the number of your issue next to the #. Pr must link to an issue-->

Closes #5 

## Description

<!-- Why are you making this change? What changes did you make? Describe your changes in detail -->
* Added 'Player' Schema that works independently from 'User' schema with userId and score fields
* Added leaderboard page with CMS payload local API that shows top 10 player scores
* API fetches top 10 scores sorted in descending order
* Leaderboard API separated via block indentation to frontend components for modularity later :D
* Frontend tester website has a 'go back to dashboard' button for usability, page layout is modular for easy editing

## Checklist

- [ ] Make sure you are requesting to **pull a feature/fix branch** (right side). Don't request the main branch!
- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start _your branch_ off _main branch_.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).

## How To Review

<!-- What (rough) order should the reviewer view your files? -->
Please check through player schema first, then frontend/leaderboard files.

## Notes

<!-- Is there anything else we need to know? Did you do any testing? Are there any risks to this pr? -->
CMS API is set to sort and fetch scores on refresh. Currently this fetches in O(n log n) time, where n is the number of total scores held in MongoDB. We can implement a faster solution where we do a pass through every element of stored scores, saving the top 10 scores, with a counter that resets on every element from 0-9, for every value v (score) in n (scores), we do k (max 9) comparisons with the top 10 scores using the counter against v to see if it's smaller than the k'th value.

The scores remain unsorted but we guarantee O(n * 1<k) runtime every time we want the leaderboard, with k never being higher than 10 (number of scores we want). Something to think about if we ever reach a point with millions of scores coming in monthly :P