### PR TITLE
feat: add game card component

### DIFF
--- a/app/(frontend)/components/gameCard.tsx
+++ b/app/(frontend)/components/gameCard.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import Image from "next/image";
+
+type GameCardProps = {
+  title?: string;
+  image?: string;
+  description?: string;
+  link?: string;
+  variant?: "card" | "list";
+};
+
+export default function GameCard({ title = "Untitled", image, description, link, variant = "card" }: GameCardProps) {
+  // Wrapper - if there's a link, use <Link> (clickable link). Otherwise, use a plain <div> (not clickable).
+  const Wrapper = link
+    ? ({ children, className }: { children: React.ReactNode; className: string }) => (
+        <Link href={link} className={className}>{children}</Link>
+      )
+    : ({ children, className }: { children: React.ReactNode; className: string }) => (
+        <div className={className}>{children}</div>
+      );
+
+  // List variant - horizontal row, no image for list layout
+  if (variant === "list") {
+    return (
+      <Wrapper
+        className={`group flex items-center justify-between gap-4 px-5 py-4 rounded-lg bg-gray-900 border border-gray-800
+                   ${link ? "hover:border-sky-600 cursor-pointer" : "opacity-75 cursor-default"} transition duration-300`}
+      >
+        <h3 className="text-base font-bold text-white min-w-0 truncate">{title}</h3>
+
+        {description && (
+          <p className="text-sm text-gray-400 truncate flex-1 min-w-0">{description}</p>
+        )}
+
+        <span className={`text-sm shrink-0 ${link ? "text-sky-500" : "text-gray-500 italic"}`}>
+          {link ? "View →" : "Coming soon"}
+        </span>
+      </Wrapper>
+    );
+  }
+
+  // Card variant - for grid layout
+  return (
+    <Wrapper
+      className={`group block rounded-2xl overflow-hidden bg-gray-900 border border-gray-800 
+                 ${link ? "hover:border-sky-600 cursor-pointer" : "opacity-75 cursor-default"} transition duration-300`}
+    >
+      {/* Image section */}
+      <div className="relative w-full aspect-video bg-gray-800">
+        {image ? (
+          <Image
+            src={image}
+            alt={title}
+            fill
+            className="object-cover"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-gray-500 text-sm">
+            No image available
+          </div>
+        )}
+      </div>
+
+      {/* Text section */}
+      <div className="p-4 flex flex-col gap-2">
+        <h3 className="text-lg font-bold text-white truncate">{title}</h3>
+
+        {description && (
+          <p className="text-sm text-gray-400 line-clamp-2">{description}</p>
+        )}
+
+        {!link && (
+          <p className="text-sm text-gray-500 italic">Coming soon</p>
+        )}
+      </div>
+    </Wrapper>
+  );
+}

--- a/app/(frontend)/components/gameCard.tsx
+++ b/app/(frontend)/components/gameCard.tsx
@@ -9,20 +9,23 @@ type GameCardProps = {
   variant?: "card" | "list";
 };
 
-export default function GameCard({ title = "Untitled", image, description, link, variant = "card" }: GameCardProps) {
-  // Wrapper - if there's a link, use <Link> (clickable link). Otherwise, use a plain <div> (not clickable).
-  const Wrapper = link
-    ? ({ children, className }: { children: React.ReactNode; className: string }) => (
-        <Link href={link} className={className}>{children}</Link>
-      )
-    : ({ children, className }: { children: React.ReactNode; className: string }) => (
-        <div className={className}>{children}</div>
-      );
+function Wrapper({ link, children, className }: { link?: string; children: React.ReactNode; className: string }) {
+  if (link) {
+    return (
+      <Link href={link} className={className}>
+        {children}
+      </Link>
+    );
+  }
+  return <div className={className}>{children}</div>;
+}
 
+export default function GameCard({ title = "Untitled", image, description, link, variant = "card" }: GameCardProps) {
   // List variant - horizontal row, no image for list layout
   if (variant === "list") {
     return (
       <Wrapper
+        link={link}
         className={`group flex items-center justify-between gap-4 px-5 py-4 rounded-lg bg-gray-900 border border-gray-800
                    ${link ? "hover:border-sky-600 cursor-pointer" : "opacity-75 cursor-default"} transition duration-300`}
       >
@@ -42,6 +45,7 @@ export default function GameCard({ title = "Untitled", image, description, link,
   // Card variant - for grid layout
   return (
     <Wrapper
+      link={link}
       className={`group block rounded-2xl overflow-hidden bg-gray-900 border border-gray-800 
                  ${link ? "hover:border-sky-600 cursor-pointer" : "opacity-75 cursor-default"} transition duration-300`}
     >

--- a/app/(frontend)/exampleCollection/page.tsx
+++ b/app/(frontend)/exampleCollection/page.tsx
@@ -1,6 +1,7 @@
 import { getPayload } from "payload";
 import config from "@/payload.config";
 import ExampleCollectionDisplay from "./components/exampleCollectionDisplay";
+import GameCard from "@/app/(frontend)/components/gameCard";
 
 
 export default async function ExampleColectionPage() {
@@ -10,12 +11,102 @@ export default async function ExampleColectionPage() {
     collection: "example",
   });
 
+  // Test data for GameCard
+  const testGames = [
+    {
+      title: "Untitled Project 1",
+      image: "/Rapture_Large_2500-1000.png",
+      description: "Descriptionnnnnnnnnnn",
+      link: "/games/1",
+      // title, image, description + link
+    }, 
+    {
+      title: "Untitled Project 2",
+      description: "More description",
+      link: "/games/2",
+      // no image 
+    },
+    {
+      title: "Untitled Project 333333333333333333333333333333333333333333333333333333",
+      image: "/Rapture_Large_2500-1000.png",
+      description:
+        "Description for project 3 testing very long text. Türhüter sagt, versteht, doch ließt in Mann, um Eintreten, ob er, aber als derstehn seinem Gesetz steht er sagt der Türhüter Türhüter. Zu dich den das Tor zu warten, um Gesetz. Als dich so lockt sich, schwart, versetzt er als der jetz. Als der dere zum Eintritten, sagt das Gesetz mein Türhüter als er also lockt, lacht eintreten Anblich das Gesem Gesetz mehr er nich, tritt, bückt einmal ste Türhüter. Zu dicht. Da das meinzugänglick der unter kommt eines doch jetz mer Mann über: Ich jetz. Aber Tür s",
+      link: "/games/3",
+      // long description + long title
+    },
+    {
+      title: "Untitled Project 4",
+      link: "/games/4",
+      // no image, no description
+    },
+    {
+      title: "Untitled Project 5",
+      image: "/Rapture_Large_2500-1000.png",
+      description: "Moreeee randommmmm descriptionnnnnn.",
+      link: "/games/5",
+      // title, image, description + link again
+    }, 
+    {
+      title: "Untitled Project 6",
+      description: "yup another description yayyyyyy.",
+      link: "/games/6",
+      // no image
+    },
+    {
+      image: "/Rapture_Large_2500-1000.png",
+      link: "/games/7",
+      // no description + no title
+    },
+    {
+      title: "Untitled Project 8",
+      image: "/Rapture_Large_2500-1000.png",
+      description: "for coming soon games that are possibly still in development yay",
+      // no link — coming soon games
+    },
+  ];
+
   return (
     <div>
       <h1>Example Collection Display</h1>
       {examples.docs.map((example) => (
         <ExampleCollectionDisplay key={example.title} example={example} />
       ))}
+
+      {/* GameCard Test Section — Grid */}
+      <div className="p-10">
+        <h2 className="text-2xl font-bold mb-2">GameCard Test — Grid Layout</h2>
+        <p className="text-gray-400 mb-6">Testing GameCard in a grid layout</p>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {testGames.map((game) => (
+            <GameCard
+              key={game.link}
+              title={game.title}
+              image={game.image}
+              description={game.description}
+              link={game.link}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* GameCard Test Section — List */}
+      <div className="p-10">
+        <h2 className="text-2xl font-bold mb-2">GameCard Test — List Layout</h2>
+        <p className="text-gray-400 mb-6">Testing GameCard in a list layout</p>
+
+        <div className="flex flex-col gap-3">
+          {testGames.map((game) => (
+            <GameCard
+              key={game.link}
+              title={game.title}
+              description={game.description}
+              link={game.link}
+              variant="list"
+            />
+          ))}
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/(frontend)/exampleCollection/page.tsx
+++ b/app/(frontend)/exampleCollection/page.tsx
@@ -112,6 +112,7 @@ export default async function ExampleColectionPage() {
             />
           ))}
         </div>
+      </div>
       <div style={{ marginTop: '2rem', padding: '1rem', border: '1px solid #ccc' }}>
         <h2>Test News Submission Component</h2>
         <NewsSubmission isAdmin={isAdmin} />

--- a/app/random1/page.tsx
+++ b/app/random1/page.tsx
@@ -3,12 +3,9 @@ it is bugged. has issues*/
 
 //from page.tsx original
 import { headers as getHeaders } from "next/headers.js";
-import Image from "next/image";
-import { fileURLToPath } from "url";
 import { getPayload } from "payload";
 import config from "@/payload.config";
 //import "./styles.css";
-import Link from "next/link";
 
 import Navbar from "@/app/(frontend)/components/navbar.tsx";
 
@@ -17,8 +14,6 @@ export default async function Page() {
     const payload = await getPayload({ config: payloadConfig });
     const headers = await getHeaders();
     const { user } = await payload.auth({ headers });
-    
-    const fileURL = `vscode://file/${fileURLToPath(import.meta.url)}`;
 
     const itemsNav = [
         { id: 1, name: "Home", link: "/" },

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -68,10 +68,10 @@ export interface Config {
   blocks: {};
   collections: {
     users: User;
-    products: Product;
     example: Example;
     Players: Player;
     Cart: Cart;
+    products: Product;
     'payload-kv': PayloadKv;
     'payload-locked-documents': PayloadLockedDocument;
     'payload-preferences': PayloadPreference;
@@ -80,10 +80,10 @@ export interface Config {
   collectionsJoins: {};
   collectionsSelect: {
     users: UsersSelect<false> | UsersSelect<true>;
-    products: ProductsSelect<false> | ProductsSelect<true>;
     example: ExampleSelect<false> | ExampleSelect<true>;
     Players: PlayersSelect<false> | PlayersSelect<true>;
     Cart: CartSelect<false> | CartSelect<true>;
+    products: ProductsSelect<false> | ProductsSelect<true>;
     'payload-kv': PayloadKvSelect<false> | PayloadKvSelect<true>;
     'payload-locked-documents': PayloadLockedDocumentsSelect<false> | PayloadLockedDocumentsSelect<true>;
     'payload-preferences': PayloadPreferencesSelect<false> | PayloadPreferencesSelect<true>;
@@ -151,23 +151,6 @@ export interface User {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "products".
- */
-export interface Product {
-  id: string;
-  name: string;
-  /**
-   * Price in cents (e.g., 1000 = $10.00)
-   */
-  price: number;
-  currency: 'NZD' | 'AUD' | 'USD' | 'EUR' | 'GBP';
-  description?: string | null;
-  updatedAt: string;
-  createdAt: string;
-  _status?: ('draft' | 'published') | null;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "example".
  */
 export interface Example {
@@ -208,6 +191,23 @@ export interface Cart {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "products".
+ */
+export interface Product {
+  id: string;
+  name: string;
+  /**
+   * Price in cents (e.g., 1000 = $10.00)
+   */
+  price: number;
+  currency: 'NZD' | 'AUD' | 'USD' | 'EUR' | 'GBP';
+  description?: string | null;
+  updatedAt: string;
+  createdAt: string;
+  _status?: ('draft' | 'published') | null;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "payload-kv".
  */
 export interface PayloadKv {
@@ -235,10 +235,6 @@ export interface PayloadLockedDocument {
         value: string | User;
       } | null)
     | ({
-        relationTo: 'products';
-        value: string | Product;
-      } | null)
-    | ({
         relationTo: 'example';
         value: string | Example;
       } | null)
@@ -249,6 +245,10 @@ export interface PayloadLockedDocument {
     | ({
         relationTo: 'Cart';
         value: string | Cart;
+      } | null)
+    | ({
+        relationTo: 'products';
+        value: string | Product;
       } | null);
   globalSlug?: string | null;
   user: {
@@ -317,19 +317,6 @@ export interface UsersSelect<T extends boolean = true> {
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema
- * via the `definition` "products_select".
- */
-export interface ProductsSelect<T extends boolean = true> {
-  name?: T;
-  price?: T;
-  currency?: T;
-  description?: T;
-  updatedAt?: T;
-  createdAt?: T;
-  _status?: T;
-}
-/**
- * This interface was referenced by `Config`'s JSON-Schema
  * via the `definition` "example_select".
  */
 export interface ExampleSelect<T extends boolean = true> {
@@ -364,6 +351,19 @@ export interface CartSelect<T extends boolean = true> {
       };
   updatedAt?: T;
   createdAt?: T;
+}
+/**
+ * This interface was referenced by `Config`'s JSON-Schema
+ * via the `definition` "products_select".
+ */
+export interface ProductsSelect<T extends boolean = true> {
+  name?: T;
+  price?: T;
+  currency?: T;
+  description?: T;
+  updatedAt?: T;
+  createdAt?: T;
+  _status?: T;
 }
 /**
  * This interface was referenced by `Config`'s JSON-Schema


### PR DESCRIPTION
## Issues

Closes #11 

## Description

Introduces a new flexible and reusable GameCard component designed to render game data consistently across grid and list layouts. 

Key changes include:
- **GameCard Component (app/(frontend)/components/gameCard.tsx)**: Created a card component that supports both grid and list views. It is built to handle edge cases such as missing images or varied text lengths, without breaking the layout.
- **Example Implementation (app/(frontend)/exampleCollection/page.tsx)**: Added a testing section to example collections page and verify the component's functionality, ensuring it behaves correctly with mock data.
- **Type Updates (payload-types.ts)**: Automatically updated payload types.


## Checklist

- [ ] Make sure you are requesting to **pull a feature/fix branch** (right side). Don't request the main branch!
- [ ] Make sure you are making a pull request against the **main branch** (left side). Also you should start _your branch_ off _main branch_.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation (if appropriate).

## How To Review

1. app/(frontend)/components/gameCard.tsx
2. app/(frontend)/exampleCollection/page.tsx
3. payload-types.ts

## Notes

### Testing
**1. Individual Card Display Information Test (For Grid and List Layouts):**
  a. Title, Description, Image and Link:
<img width="385" height="336" alt="Screenshot 2026-04-30 at 9 54 52 AM" src="https://github.com/user-attachments/assets/a9fec057-4471-4e82-8f1c-6c01b69773da" />
<img width="1179" height="74" alt="Screenshot 2026-04-30 at 9 56 44 AM" src="https://github.com/user-attachments/assets/89734f3d-4d19-4485-8694-b6c0c1087864" />

  b. Title, Description, No Image and Link:
<img width="387" height="333" alt="Screenshot 2026-04-30 at 9 55 25 AM" src="https://github.com/user-attachments/assets/4239141d-d507-467d-9b1d-911b5df5ac50" />
<img width="1176" height="72" alt="Screenshot 2026-04-30 at 9 57 01 AM" src="https://github.com/user-attachments/assets/077441c2-6012-4aeb-9915-17c0d488972c" />

  c. Title, No Description, No Image and Link:
<img width="383" height="309" alt="Screenshot 2026-04-30 at 9 56 00 AM" src="https://github.com/user-attachments/assets/9e8387a7-2725-4218-90f9-555662a66062" />
<img width="1172" height="68" alt="Screenshot 2026-04-30 at 9 57 15 AM" src="https://github.com/user-attachments/assets/d7d19d18-bf86-46a8-937a-eabfaada67b1" />

  d. No Title, No Description, No Image and Link (Title defaults to "Untitled"):
<img width="381" height="357" alt="Screenshot 2026-04-30 at 9 59 06 AM" src="https://github.com/user-attachments/assets/167202f6-d8db-49c3-9d60-b05288d261e3" />
<img width="1169" height="68" alt="Screenshot 2026-04-30 at 9 58 16 AM" src="https://github.com/user-attachments/assets/2f1381d4-e1ae-433d-bd1a-3ba16af4b5b6" />

  e. Title, Description, No Image and No Link (i.e. for coming soon games - generates 'Coming Soon' message, no hover over transition/animation, opacity increased, 'View' in list layout changed to 'Coming Soon'):
<img width="388" height="360" alt="Screenshot 2026-04-30 at 10 03 39 AM" src="https://github.com/user-attachments/assets/6bcaa5ce-4103-4469-b799-b430407efcb1" />
<img width="1170" height="67" alt="Screenshot 2026-04-30 at 10 03 51 AM" src="https://github.com/user-attachments/assets/4339aac5-5917-459f-9e2a-af468dfd0629" />

**2. Grid Layout Tests:**
  a. Extra Large Display (Full screen) - 4 card per row:
<img width="1408" height="738" alt="Screenshot 2026-04-30 at 9 40 13 AM" src="https://github.com/user-attachments/assets/d79316d3-a75d-4a2f-a832-04a0fe1baea5" />

  b. Large Display (slightly slimmer window) - 3 card per row:
<img width="1054" height="691" alt="Screenshot 2026-04-30 at 9 50 44 AM" src="https://github.com/user-attachments/assets/6bbd51e5-0197-4e86-be4c-3beecad820be" />

  c. Small Display (even slimmer window) - 2 card per row:
<img width="818" height="754" alt="Screenshot 2026-04-30 at 9 52 51 AM" src="https://github.com/user-attachments/assets/5b7ceb8d-7986-4f9a-ac00-00e289470c1a" />

  d. Smallest Display - 1 card per row:
<img width="552" height="650" alt="Screenshot 2026-04-30 at 9 53 26 AM" src="https://github.com/user-attachments/assets/7453bd1f-368e-4bfc-9195-91f0afea2a80" />

**3. List Layout Tests:**
  - Makes sure title does not truncate until description cannot truncate anymore
  - Link text does not truncate
<img width="1398" height="644" alt="Screenshot 2026-04-30 at 10 37 58 AM" src="https://github.com/user-attachments/assets/c3719ea6-e521-4457-a8c6-bae0e1ae1691" />
<img width="808" height="664" alt="Screenshot 2026-04-30 at 10 38 18 AM" src="https://github.com/user-attachments/assets/2b7d120a-3106-47bc-a482-b6675ea22854" />
<img width="541" height="654" alt="Screenshot 2026-04-30 at 10 38 57 AM" src="https://github.com/user-attachments/assets/ee240e2b-7d04-40ed-894f-0a5e908572aa" />

### Additional Notes
- payload-types.ts was modified either by pnpm run dev command or pnpm payload generate-types
- Tested via example collection page as shown above

